### PR TITLE
Fix bug modal for teacher add course wasn't opening/closing

### DIFF
--- a/client/src/components/teacher/TeacherView.jsx
+++ b/client/src/components/teacher/TeacherView.jsx
@@ -264,14 +264,14 @@ function TeacherView() {
             className="text-xl border-solid border-2 w-fit p-2 rounded-md self-center"
             onClick={(e) => {
               e.preventDefault();
-              handleOpen();
+              handleOpen("course");
             }}
           >
-            Add course
+            Add Course
           </button>
-          <Modal open={isAddingCourse} onClose={handleClose}>
+          <Modal open={isAddingCourse} onClose={() => handleClose("course")}>
             <TeacherAddCourse
-              handleClose={handleClose}
+              handleClose={() => handleClose("course")}
               addNewCourse={handleCourseAddition}
             />
           </Modal>


### PR DESCRIPTION
Fix bug modal for teacher add course wasn't opening/closing since the opening and closing functions for the modal were not targeting the modal in question at all

Expected call: `handleOpen("course")` VS Actual call: `handleOpen()`